### PR TITLE
Add script for comparing multiple ASR predictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# transcribe
+# Speech Model Inference and Evaluation
+
+This repository contains scripts to run speech recognition inference with several open-source models and to evaluate their quality.
+
+## Inference
+
+Each model has its own script under `models/`:
+
+- `inference_canary.py` – [NVIDIA Canary 1B v2](https://huggingface.co/nvidia/canary-1b-v2)
+- `inference_whisper.py` – [OpenAI Whisper large v3](https://huggingface.co/openai/whisper-large-v3)
+- `inference_gigaam.py` – [Salute GigaAM v2](https://github.com/salute-developers/GigaAM)
+- `inference_silero.py` – [Silero STT](https://github.com/snakers4/silero-models)
+- `inference_vosk.py` – [Vosk](https://alphacephei.com/vosk)
+
+Usage is similar for all scripts:
+
+```bash
+python models/inference_whisper.py <path/to/audio_or_dir> predictions.json
+```
+
+Results are written as JSON mapping audio paths to transcribed text.
+
+For a broader overview of Russian speech recognition projects, see resources like the [Alpha Cephei blog](https://alphacephei.com/nsh/2025/04/18/russian-models.html) which surveys Vosk, Silero, Whisper and other models.
+
+## Evaluation
+
+To compare predictions with reference transcripts, use:
+
+```bash
+python evaluation/evaluate_transcriptions.py reference.json predictions.json
+```
+
+The script prints word error rate (WER), character error rate (CER) and a semantic similarity score using Sentence-Transformers.
+
+To evaluate several model outputs in one run:
+
+```bash
+python evaluation/compare_transcriptions.py reference.json whisper.json canary.json gigaam.json
+```
+
+This prints metrics for each predictions file, allowing quick comparison between models.
+
+## Requirements
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+# For GigaAM
+pip install git+https://github.com/salute-developers/GigaAM
+```
+
+Ensure `ffmpeg` is available for audio decoding.
+

--- a/evaluation/compare_transcriptions.py
+++ b/evaluation/compare_transcriptions.py
@@ -1,0 +1,65 @@
+"""Compare multiple ASR prediction sets against references using lexical and semantic metrics."""
+import argparse
+import json
+import string
+from pathlib import Path
+
+from jiwer import wer, cer
+from sentence_transformers import SentenceTransformer, util
+
+
+def normalize(text: str) -> str:
+    """Lower-case and strip punctuation."""
+    text = text.lower()
+    return text.translate(str.maketrans("", "", string.punctuation))
+
+
+def load_json(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def evaluate(refs: dict, preds: dict, model: SentenceTransformer) -> tuple[float, float, float]:
+    """Return WER, CER and semantic similarity for matching keys."""
+    refs_norm, preds_norm = [], []
+    for k, ref in refs.items():
+        if k in preds:
+            refs_norm.append(normalize(ref))
+            preds_norm.append(normalize(preds[k]))
+    if not refs_norm:
+        raise ValueError("No matching keys between references and predictions")
+
+    w_error = wer(refs_norm, preds_norm)
+    c_error = cer(refs_norm, preds_norm)
+    ref_emb = model.encode(refs_norm, convert_to_tensor=True)
+    pred_emb = model.encode(preds_norm, convert_to_tensor=True)
+    semantic = float(util.cos_sim(ref_emb, pred_emb).diagonal().mean())
+    return w_error, c_error, semantic
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("references", type=str, help="Path to reference transcripts JSON")
+    parser.add_argument("predictions", nargs="+", help="Prediction JSON files to compare")
+    parser.add_argument(
+        "--model",
+        default="paraphrase-multilingual-mpnet-base-v2",
+        help="Sentence-transformer model for semantic similarity",
+    )
+    args = parser.parse_args()
+
+    refs = load_json(Path(args.references))
+    st_model = SentenceTransformer(args.model)
+
+    for pred_path in args.predictions:
+        preds = load_json(Path(pred_path))
+        wer_score, cer_score, semantic = evaluate(refs, preds, st_model)
+        label = Path(pred_path).stem
+        print(f"\nResults for {label}:")
+        print(f"WER: {wer_score:.4f}")
+        print(f"CER: {cer_score:.4f}")
+        print(f"Semantic similarity: {semantic:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/evaluate_transcriptions.py
+++ b/evaluation/evaluate_transcriptions.py
@@ -1,0 +1,61 @@
+"""Evaluate ASR predictions against references using lexical and semantic metrics."""
+import argparse
+import json
+import string
+from pathlib import Path
+
+from jiwer import cer, wer
+from sentence_transformers import SentenceTransformer, util
+
+
+TRANSFORMER_MODEL = "paraphrase-multilingual-mpnet-base-v2"
+
+
+def normalize(text: str) -> str:
+    text = text.lower()
+    return text.translate(str.maketrans("", "", string.punctuation))
+
+
+def load_json(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("references", type=str, help="Path to reference transcripts JSON")
+    parser.add_argument("predictions", type=str, help="Path to predictions JSON")
+    parser.add_argument(
+        "--model", default=TRANSFORMER_MODEL, help="Sentence-transformer model for semantic similarity"
+    )
+    args = parser.parse_args()
+
+    refs = load_json(Path(args.references))
+    preds = load_json(Path(args.predictions))
+
+    refs_norm = []
+    preds_norm = []
+    ids = []
+    for k, ref in refs.items():
+        if k in preds:
+            ids.append(k)
+            refs_norm.append(normalize(ref))
+            preds_norm.append(normalize(preds[k]))
+
+    if not ids:
+        raise ValueError("No matching keys between references and predictions")
+
+    w_error = wer(refs_norm, preds_norm)
+    c_error = cer(refs_norm, preds_norm)
+    print(f"WER: {w_error:.4f}\nCER: {c_error:.4f}")
+
+    model = SentenceTransformer(args.model)
+    ref_emb = model.encode(refs_norm, convert_to_tensor=True)
+    pred_emb = model.encode(preds_norm, convert_to_tensor=True)
+    cosine_scores = util.cos_sim(ref_emb, pred_emb).diagonal()
+    semantic = float(cosine_scores.mean())
+    print(f"Semantic similarity: {semantic:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/inference_canary.py
+++ b/models/inference_canary.py
@@ -1,0 +1,50 @@
+"""Transcribe audio files using NVIDIA Canary-1B-v2 model."""
+import argparse
+import json
+import os
+from pathlib import Path
+
+import soundfile as sf
+import torch
+from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq
+
+MODEL_ID = "nvidia/canary-1b-v2"
+
+
+def transcribe_file(model, processor, path: Path) -> str:
+    audio, sr = sf.read(str(path))
+    inputs = processor(audio, sampling_rate=sr, return_tensors="pt")
+    inputs = inputs.to(model.device)
+    with torch.no_grad():
+        generated_ids = model.generate(**inputs)
+    transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+    return transcription
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=str, help="Path to an audio file or directory")
+    parser.add_argument("output", type=str, help="Path to output JSON file")
+    args = parser.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    processor = AutoProcessor.from_pretrained(MODEL_ID)
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(MODEL_ID)
+    model.to(device)
+
+    input_path = Path(args.input)
+    audio_files = [input_path] if input_path.is_file() else sorted(
+        p for p in input_path.glob("**/*") if p.suffix.lower() in {".wav", ".flac", ".mp3"}
+    )
+
+    results = {}
+    for audio_path in audio_files:
+        print(f"Transcribing {audio_path}...")
+        results[str(audio_path)] = transcribe_file(model, processor, audio_path)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/inference_gigaam.py
+++ b/models/inference_gigaam.py
@@ -1,0 +1,40 @@
+"""Transcribe audio files using GigaAM v2 model."""
+import argparse
+import json
+from pathlib import Path
+
+import soundfile as sf  # ensures dependency available if audio pre-processing needed
+import gigaam
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=str, help="Path to an audio file or directory")
+    parser.add_argument("output", type=str, help="Path to output JSON file")
+    parser.add_argument(
+        "--model", default="v2_rnnt", help="Model type: v2_rnnt, v2_ctc, rnnt, ctc, etc."
+    )
+    args = parser.parse_args()
+
+    model = gigaam.load_model(args.model)
+
+    input_path = Path(args.input)
+    audio_files = [input_path] if input_path.is_file() else sorted(
+        p for p in input_path.glob("**/*") if p.suffix.lower() in {".wav", ".flac", ".mp3"}
+    )
+
+    results = {}
+    for audio_path in audio_files:
+        print(f"Transcribing {audio_path}...")
+        transcription = model.transcribe(str(audio_path))
+        # some versions may return dict with 'transcription' key
+        if isinstance(transcription, dict):
+            transcription = transcription.get("transcription") or transcription.get("text") or ""
+        results[str(audio_path)] = transcription
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/inference_silero.py
+++ b/models/inference_silero.py
@@ -1,0 +1,56 @@
+"""Transcribe audio files using Silero STT model."""
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+
+def load_model(device):
+    model, decoder, utils = torch.hub.load(
+        repo_or_dir="snakers4/silero-models",
+        model="silero_stt",
+        language="ru",
+        model_id="ru_v4"
+    )
+    (read_batch, split_into_batches, read_audio, prepare_model_input) = utils
+    model.to(device)
+    return model, decoder, read_audio, split_into_batches, prepare_model_input
+
+
+def transcribe_file(model, decoder, read_audio, split_into_batches, prepare_model_input, path: Path) -> str:
+    audio = read_audio(str(path))
+    batches = split_into_batches([audio], batch_size=1)
+    input_data = prepare_model_input(batches, device=model.device)
+    output = model(input_data)
+    transcription = decoder(output[0].cpu())
+    return transcription
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=str, help="Path to an audio file or directory")
+    parser.add_argument("output", type=str, help="Path to output JSON file")
+    args = parser.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model, decoder, read_audio, split_into_batches, prepare_model_input = load_model(device)
+
+    input_path = Path(args.input)
+    audio_files = [input_path] if input_path.is_file() else sorted(
+        p for p in input_path.glob("**/*") if p.suffix.lower() in {".wav", ".flac", ".mp3"}
+    )
+
+    results = {}
+    for audio_path in audio_files:
+        print(f"Transcribing {audio_path}...")
+        results[str(audio_path)] = transcribe_file(
+            model, decoder, read_audio, split_into_batches, prepare_model_input, audio_path
+        )
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/inference_vosk.py
+++ b/models/inference_vosk.py
@@ -1,0 +1,47 @@
+"""Transcribe audio files using Vosk offline model."""
+import argparse
+import json
+from pathlib import Path
+import wave
+
+from vosk import Model, KaldiRecognizer
+
+
+def transcribe_file(model: Model, path: Path) -> str:
+    with wave.open(str(path), "rb") as wf:
+        rec = KaldiRecognizer(model, wf.getframerate())
+        rec.SetWords(True)
+        while True:
+            data = wf.readframes(4000)
+            if len(data) == 0:
+                break
+            rec.AcceptWaveform(data)
+        result = json.loads(rec.FinalResult())
+    return result.get("text", "")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", type=str, help="Path to Vosk model directory")
+    parser.add_argument("input", type=str, help="Path to an audio file or directory of WAV files")
+    parser.add_argument("output", type=str, help="Path to output JSON file")
+    args = parser.parse_args()
+
+    model = Model(args.model)
+
+    input_path = Path(args.input)
+    audio_files = [input_path] if input_path.is_file() else sorted(
+        p for p in input_path.glob("**/*") if p.suffix.lower() == ".wav"
+    )
+
+    results = {}
+    for audio_path in audio_files:
+        print(f"Transcribing {audio_path}...")
+        results[str(audio_path)] = transcribe_file(model, audio_path)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/inference_whisper.py
+++ b/models/inference_whisper.py
@@ -1,0 +1,49 @@
+"""Transcribe audio files using OpenAI Whisper-large-v3 model."""
+import argparse
+import json
+from pathlib import Path
+
+import soundfile as sf
+import torch
+from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
+
+MODEL_ID = "openai/whisper-large-v3"
+
+
+def transcribe_file(model, processor, path: Path) -> str:
+    audio, sr = sf.read(str(path))
+    inputs = processor(audio, sampling_rate=sr, return_tensors="pt")
+    inputs = inputs.to(model.device)
+    with torch.no_grad():
+        generated_ids = model.generate(**inputs)
+    transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+    return transcription
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=str, help="Path to an audio file or directory")
+    parser.add_argument("output", type=str, help="Path to output JSON file")
+    args = parser.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    processor = AutoProcessor.from_pretrained(MODEL_ID)
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(MODEL_ID)
+    model.to(device)
+
+    input_path = Path(args.input)
+    audio_files = [input_path] if input_path.is_file() else sorted(
+        p for p in input_path.glob("**/*") if p.suffix.lower() in {".wav", ".flac", ".mp3"}
+    )
+
+    results = {}
+    for audio_path in audio_files:
+        print(f"Transcribing {audio_path}...")
+        results[str(audio_path)] = transcribe_file(model, processor, audio_path)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+transformers>=4.39.0
+torch
+soundfile
+jiwer
+sentence-transformers
+torchaudio
+vosk
+# GigaAM requires extra installation
+# pip install git+https://github.com/salute-developers/GigaAM


### PR DESCRIPTION
## Summary
- Add `compare_transcriptions.py` utility to compute WER/CER and semantic similarity across multiple model outputs
- Document multi-model evaluation usage in README

## Testing
- `python -m py_compile models/inference_canary.py models/inference_whisper.py models/inference_gigaam.py evaluation/evaluate_transcriptions.py evaluation/compare_transcriptions.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba49e1bff88326b45d129932d0fb6b