### PR TITLE
Add SER and error breakdown to evaluation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ To compare predictions with reference transcripts, use:
 python evaluation/evaluate_transcriptions.py reference.json predictions.json
 ```
 
-The script prints word error rate (WER), character error rate (CER) and a semantic similarity score using Sentence-Transformers.
+The script prints word error rate (WER), character error rate (CER), sentence error rate (SER) and a semantic similarity score. It
+also reports counts of substitutions, insertions and deletions.
 
 To evaluate several model outputs in one run:
 
@@ -38,7 +39,7 @@ To evaluate several model outputs in one run:
 python evaluation/compare_transcriptions.py reference.json whisper.json canary.json gigaam.json
 ```
 
-This prints metrics for each predictions file, allowing quick comparison between models.
+This prints the same set of metrics for each predictions file, allowing quick comparison between models.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- compute sentence error rate (SER) and substitution/insert/delete counts in evaluation tools
- expose same metrics in comparison script and documentation

## Testing
- `python -m py_compile evaluation/evaluate_transcriptions.py evaluation/compare_transcriptions.py`
- `python evaluation/evaluate_transcriptions.py refs.json preds.json` *(fails: Unable to download sentence-transformers model)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4cb79cc88326a2d62258ef599d5e