### PR TITLE
Optimize inference scripts with eval and inference_mode

### DIFF
--- a/models/inference_canary.py
+++ b/models/inference_canary.py
@@ -15,7 +15,7 @@ def transcribe_file(model, processor, path: Path) -> str:
     audio, sr = sf.read(str(path))
     inputs = processor(audio, sampling_rate=sr, return_tensors="pt")
     inputs = inputs.to(model.device)
-    with torch.no_grad():
+    with torch.inference_mode():
         generated_ids = model.generate(**inputs)
     transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
     return transcription
@@ -30,7 +30,7 @@ def main() -> None:
     device = "cuda" if torch.cuda.is_available() else "cpu"
     processor = AutoProcessor.from_pretrained(MODEL_ID)
     model = AutoModelForSpeechSeq2Seq.from_pretrained(MODEL_ID)
-    model.to(device)
+    model.to(device).eval()
 
     input_path = Path(args.input)
     audio_files = [input_path] if input_path.is_file() else sorted(

--- a/models/inference_silero.py
+++ b/models/inference_silero.py
@@ -11,10 +11,10 @@ def load_model(device):
         repo_or_dir="snakers4/silero-models",
         model="silero_stt",
         language="ru",
-        model_id="ru_v4"
+        model_id="ru_v4",
     )
     (read_batch, split_into_batches, read_audio, prepare_model_input) = utils
-    model.to(device)
+    model.to(device).eval()
     return model, decoder, read_audio, split_into_batches, prepare_model_input
 
 
@@ -22,7 +22,8 @@ def transcribe_file(model, decoder, read_audio, split_into_batches, prepare_mode
     audio = read_audio(str(path))
     batches = split_into_batches([audio], batch_size=1)
     input_data = prepare_model_input(batches, device=model.device)
-    output = model(input_data)
+    with torch.inference_mode():
+        output = model(input_data)
     transcription = decoder(output[0].cpu())
     return transcription
 

--- a/models/inference_whisper.py
+++ b/models/inference_whisper.py
@@ -14,7 +14,7 @@ def transcribe_file(model, processor, path: Path) -> str:
     audio, sr = sf.read(str(path))
     inputs = processor(audio, sampling_rate=sr, return_tensors="pt")
     inputs = inputs.to(model.device)
-    with torch.no_grad():
+    with torch.inference_mode():
         generated_ids = model.generate(**inputs)
     transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
     return transcription
@@ -29,7 +29,7 @@ def main() -> None:
     device = "cuda" if torch.cuda.is_available() else "cpu"
     processor = AutoProcessor.from_pretrained(MODEL_ID)
     model = AutoModelForSpeechSeq2Seq.from_pretrained(MODEL_ID)
-    model.to(device)
+    model.to(device).eval()
 
     input_path = Path(args.input)
     audio_files = [input_path] if input_path.is_file() else sorted(


### PR DESCRIPTION
## Summary
- Ensure ASR models run in eval mode
- Use torch.inference_mode for gradient-free inference

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_68ba52c7179c8326b3c5de6140ce742b