### PR TITLE
Add RU Stage-1 dataset mix helper

### DIFF
--- a/models/inference_canary.py
+++ b/models/inference_canary.py
@@ -126,8 +126,17 @@ def main() -> None:
     parser.add_argument("--model_id", default=MODEL_ID, help="HF model id to use")
 
     def _default_bs(mid: str) -> int:
-        m = (mid or '').lower()
-        if 'canary' in m:
+        m = (mid or "").lower()
+        if "canary" in m:
+            try:
+                total_mem = torch.cuda.get_device_properties(0).total_memory
+            except Exception:
+                total_mem = 0
+            gb = 1024 ** 3
+            if total_mem >= 80 * gb:
+                return 128
+            if total_mem >= 40 * gb:
+                return 64
             return 32
         return 16
 

--- a/tools/build_ru_stage1_mix.py
+++ b/tools/build_ru_stage1_mix.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""
+Build the RU Stage‑1 training mix (Golos, CV, RuLibriSpeech, Podlodka,
+telephony, optional non‑speech) using methodology ratios.
+
+Each input is a JSONL manifest with at least ``audio_filepath`` and ``text``
+fields. Sampling is by number of rows; ratios sum to 1.0 and are applied to the
+requested ``--target_size``.
+
+Example:
+  python transcribe/tools/build_ru_stage1_mix.py \
+    --golos data/golos_mix.jsonl --cv data/cv17_ru.jsonl \
+    --ruls data/ruls.jsonl --podlodka data/podlodka.jsonl \
+    --telephony data/telephony.jsonl --nonspeech data/nonspeech.jsonl \
+    --out data/ru_stage1_mix.jsonl --target_size 1000000 \
+    --shuffle --seed 42 --add_dataset_tag
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from transcribe.tools.mix_manifests import reservoir_sample
+
+# Default Stage‑1 ratios from methodology (sum to 1.0)
+DEFAULT_RATIOS: Dict[str, float] = {
+    "golos": 0.35,
+    "cv": 0.25,
+    "ruls": 0.15,
+    "podlodka": 0.10,
+    "telephony": 0.10,
+    "nonspeech": 0.05,
+}
+
+
+def parse_ratio_overrides(spec: str) -> Dict[str, float]:
+    ratios: Dict[str, float] = {}
+    for part in spec.split(","):
+        if not part:
+            continue
+        name, sval = part.split("=", 1)
+        ratios[name.strip()] = float(sval)
+    total = sum(ratios.values())
+    if total <= 0:
+        raise ValueError("Sum of ratios must be > 0")
+    for k in list(ratios.keys()):
+        ratios[k] = ratios[k] / total
+    return ratios
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--golos", required=True, help="Golos manifest (crowd+farfield)")
+    ap.add_argument("--cv", required=True, help="Common Voice v17 (ru) manifest")
+    ap.add_argument("--ruls", required=True, help="Russian LibriSpeech manifest")
+    ap.add_argument("--podlodka", required=True, help="Podlodka speech manifest")
+    ap.add_argument("--telephony", required=True, help="UniDataPro telephony manifest")
+    ap.add_argument("--nonspeech", default=None, help="Optional AudioSet non‑speech manifest")
+    ap.add_argument("--out", required=True, help="Output JSONL path")
+    ap.add_argument("--target_size", type=int, required=True, help="Total rows in output mix")
+    ap.add_argument("--shuffle", action="store_true", help="Shuffle final mix")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--add_dataset_tag", action="store_true", help="Add dataset field with source name")
+    ap.add_argument("--ratios", default=None, help="Override ratios name=val,...")
+    args = ap.parse_args()
+
+    pairs: List[Tuple[str, Path]] = [
+        ("golos", Path(args.golos)),
+        ("cv", Path(args.cv)),
+        ("ruls", Path(args.ruls)),
+        ("podlodka", Path(args.podlodka)),
+        ("telephony", Path(args.telephony)),
+    ]
+    if args.nonspeech:
+        pairs.append(("nonspeech", Path(args.nonspeech)))
+
+    ratios: Dict[str, float]
+    if args.ratios:
+        ratios = parse_ratio_overrides(args.ratios)
+    else:
+        ratios = {nm: DEFAULT_RATIOS[nm] for nm, _ in pairs}
+        total = sum(ratios.values())
+        ratios = {k: v / total for k, v in ratios.items()}
+
+    target = int(args.target_size)
+    plan = {nm: int(round(ratios[nm] * target)) for nm, _ in pairs}
+    diff = target - sum(plan.values())
+    for nm, _ in pairs:
+        if diff == 0:
+            break
+        plan[nm] += 1 if diff > 0 else -1
+        diff += -1 if diff > 0 else 1
+
+    rng = random.Random(args.seed)
+    rows: List[dict] = []
+    for nm, p in pairs:
+        k = max(0, plan[nm])
+        if k == 0:
+            continue
+        sample = reservoir_sample(p, k, seed=args.seed + hash(nm) % 997)
+        if args.add_dataset_tag:
+            for r in sample:
+                r.setdefault("dataset", nm)
+        rows.extend(sample)
+
+    if args.shuffle:
+        rng.shuffle(rows)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fo:
+        for r in rows[:target]:
+            fo.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"[OK] Sampled -> {out_path} rows={min(len(rows), target)} plan={plan}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/build_ru_stage1_pipeline.py
+++ b/tools/build_ru_stage1_pipeline.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""Build the RU Stage-1 dataset pipeline.
+
+Fetch HF datasets, convert them to manifests, mix Golos parts,
+then assemble the final Stage-1 training mix using methodology ratios.
+
+This script orchestrates the following steps:
+1. `build_manifest_hf` for Common Voice, Russian LibriSpeech,
+   Podlodka, Golos crowd/farfield (and optional non-speech).
+2. Quality filter each manifest via Canary (`filter_manifest_canary`).
+3. Concatenate Golos crowd+farfield into one manifest.
+4. Invoke `build_ru_stage1_mix` to sample the final training mix.
+
+Telephony data has no HF preset, so provide its manifest via `--telephony`.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+def run(cmd: List[str], cwd: Path) -> None:
+    """Run a subprocess in ``cwd``, echoing the command."""
+    print("+", " ".join(cmd))
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out_dir", default="data", help="Directory for manifests and final mix")
+    ap.add_argument("--telephony", required=True, help="Path to telephony manifest JSONL")
+    ap.add_argument("--target_size", type=int, default=1_000_000, help="Rows in final mix")
+    ap.add_argument("--include_nonspeech", action="store_true", help="Include AudioSet non-speech preset")
+    ap.add_argument("--seed", type=int, default=42, help="Seed for shuffling")
+    ap.add_argument("--max_wer", type=float, default=0.15, help="Quality filter max WER for Canary")
+    ap.add_argument("--min_dur", type=float, default=1.0, help="Quality filter min duration (s)")
+    ap.add_argument("--max_dur", type=float, default=35.0, help="Quality filter max duration (s)")
+    ap.add_argument("--batch_size", type=int, default=None, help="Batch size for Canary inference")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    py = sys.executable
+    repo_root = Path(__file__).resolve().parents[2]
+
+    def bm(preset: str, out_path: Path) -> None:
+        cmd = [
+            py,
+            "-m",
+            "transcribe.tools.build_manifest_hf",
+            "--preset",
+            preset,
+            "--out",
+            str(out_path),
+            "--drop_empty",
+        ]
+        run(cmd, cwd=repo_root)
+
+    def filt(manifest: Path, out_path: Path) -> Path:
+        cmd = [
+            py,
+            "-m",
+            "transcribe.tools.filter_manifest_canary",
+            "--manifest",
+            str(manifest),
+            "--out",
+            str(out_path),
+            "--max_wer",
+            str(args.max_wer),
+            "--min_dur",
+            str(args.min_dur),
+            "--max_dur",
+            str(args.max_dur),
+        ]
+        if args.batch_size:
+            cmd.extend(["--batch_size", str(args.batch_size)])
+        run(cmd, cwd=repo_root)
+        return out_path
+
+    cv_raw = out_dir / "cv17_ru.jsonl"
+    ruls_raw = out_dir / "ruls.jsonl"
+    pod_raw = out_dir / "podlodka.jsonl"
+    golos_c_raw = out_dir / "golos_crowd.jsonl"
+    golos_f_raw = out_dir / "golos_farfield.jsonl"
+
+    bm("cv17-ru", cv_raw)
+    bm("ruls", ruls_raw)
+    bm("podlodka", pod_raw)
+    bm("golos-crowd", golos_c_raw)
+    bm("golos-farfield", golos_f_raw)
+
+    cv_path = filt(cv_raw, out_dir / "cv17_ru_sel.jsonl")
+    ruls_path = filt(ruls_raw, out_dir / "ruls_sel.jsonl")
+    pod_path = filt(pod_raw, out_dir / "podlodka_sel.jsonl")
+    golos_c_path = filt(golos_c_raw, out_dir / "golos_crowd_sel.jsonl")
+    golos_f_path = filt(golos_f_raw, out_dir / "golos_farfield_sel.jsonl")
+
+    nonspeech_path: Optional[Path] = None
+    if args.include_nonspeech:
+        nonspeech_path = out_dir / "nonspeech.jsonl"
+        bm("audioset-nonspeech", nonspeech_path)
+
+    telephony_path = filt(Path(args.telephony), out_dir / "telephony_sel.jsonl")
+
+    golos_mix = out_dir / "golos_mix.jsonl"
+    run(
+        [
+            py,
+            "-m",
+            "transcribe.tools.mix_manifests",
+            "--in",
+            f"crowd={golos_c_path}",
+            "--in",
+            f"farfield={golos_f_path}",
+            "--out",
+            str(golos_mix),
+            "--concat",
+        ],
+        cwd=repo_root,
+    )
+
+    cmd = [
+        py,
+        "-m",
+        "transcribe.tools.build_ru_stage1_mix",
+        "--golos",
+        str(golos_mix),
+        "--cv",
+        str(cv_path),
+        "--ruls",
+        str(ruls_path),
+        "--podlodka",
+        str(pod_path),
+        "--telephony",
+        str(telephony_path),
+        "--out",
+        str(out_dir / "ru_stage1_mix.jsonl"),
+        "--target_size",
+        str(args.target_size),
+        "--shuffle",
+        "--seed",
+        str(args.seed),
+        "--add_dataset_tag",
+    ]
+    if nonspeech_path:
+        cmd.extend(["--nonspeech", str(nonspeech_path)])
+    run(cmd, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/filter_manifest_canary.py
+++ b/tools/filter_manifest_canary.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""Transcribe a manifest with Canary and keep rows meeting quality thresholds."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import soundfile as sf
+from jiwer import wer
+
+
+def run(cmd: List[str], cwd: Path) -> None:
+    """Run a subprocess in ``cwd`` echoing the command."""
+    print("+", " ".join(cmd))
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def transcribe_if_needed(
+    manifest: Path,
+    pred_path: Path,
+    model_id: str,
+    batch_size: int | None,
+    repo_root: Path,
+) -> None:
+    if pred_path.exists():
+        return
+    cmd = [
+        sys.executable,
+        "-m",
+        "transcribe.models.inference_canary",
+        str(manifest),
+        str(pred_path),
+        "--model_id",
+        model_id,
+    ]
+    if batch_size:
+        cmd.extend(["--batch_size", str(batch_size)])
+    run(cmd, cwd=repo_root)
+
+
+def iter_jsonl(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        for ln in f:
+            ln = ln.strip()
+            if not ln:
+                continue
+            try:
+                yield json.loads(ln)
+            except Exception:
+                continue
+
+
+def write_jsonl(path: Path, rows: List[dict]) -> int:
+    n = 0
+    with path.open("w", encoding="utf-8") as fo:
+        for r in rows:
+            fo.write(json.dumps(r, ensure_ascii=False) + "\n")
+            n += 1
+    return n
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True, help="Input JSONL manifest with audio_filepath/text")
+    ap.add_argument("--out", required=True, help="Output JSONL path for filtered rows")
+    ap.add_argument("--pred", default=None, help="Optional existing predictions JSON; if missing, will run Canary")
+    ap.add_argument("--model_id", default="nvidia/canary-1b-v2", help="HF model id for Canary")
+    ap.add_argument("--batch_size", type=int, default=None, help="Batch size for Canary inference")
+    ap.add_argument("--max_wer", type=float, default=0.15, help="Maximum WER to keep a sample")
+    ap.add_argument("--min_dur", type=float, default=1.0, help="Minimum duration in seconds")
+    ap.add_argument("--max_dur", type=float, default=35.0, help="Maximum duration in seconds")
+    args = ap.parse_args()
+
+    manifest_path = Path(args.manifest)
+    out_path = Path(args.out)
+    pred_path = Path(args.pred) if args.pred else out_path.with_suffix(".pred.json")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    transcribe_if_needed(manifest_path, pred_path, args.model_id, args.batch_size, repo_root)
+
+    try:
+        preds: Dict[str, str] = json.loads(pred_path.read_text(encoding="utf-8"))
+    except Exception:
+        preds = {}
+
+    selected: List[dict] = []
+    for row in iter_jsonl(manifest_path):
+        audio = str(row.get("audio_filepath") or row.get("audio"))
+        ref = str(row.get("text") or "")
+        if not audio or not ref:
+            continue
+        try:
+            dur = float(sf.info(audio).duration)
+        except Exception:
+            try:
+                data, sr = sf.read(audio)
+                dur = len(data) / float(sr)
+            except Exception:
+                continue
+        if dur < float(args.min_dur) or dur > float(args.max_dur):
+            continue
+        pred = preds.get(audio, "")
+        if not pred:
+            continue
+        w = wer(ref, pred)
+        if w <= float(args.max_wer):
+            out_row = dict(row)
+            out_row["pred_text"] = pred
+            out_row["wer"] = float(w)
+            selected.append(out_row)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    n = write_jsonl(out_path, selected)
+    print(f"[OK] Selected {n} rows -> {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `filter_manifest_canary.py` to score manifests with Canary and keep high-quality rows
- run Canary filtering inside Stage‑1 pipeline before mixing datasets
- document Canary-based filtering, updated pipeline usage, and how to build Podlodka and telephony manifests
- allow tuning Canary batch size and auto-scale defaults for A6000-class GPUs

## Testing
- `python -m transcribe.models.inference_canary --help`
- `python -m transcribe.tools.filter_manifest_canary --help`
- `python -m transcribe.tools.build_ru_stage1_pipeline --help`
- `python -m transcribe.tools.build_ru_stage1_mix --help`
- `python -m transcribe.tools.mix_manifests --help`
- `python -m transcribe.tools.build_manifest_hf --help`
- `python -m transcribe.tools.build_manifest_hf --dataset hf-internal-testing/librispeech_asr_dummy --split validation --audio_col audio --text_col text --out transcribe/data/dummy.jsonl --drop_empty` *(fails: Couldn't reach 'hf-internal-testing/librispeech_asr_dummy' on the Hub (ProxyError))*


------
https://chatgpt.com/codex/tasks/task_e_68c09e7d075483268acfb86db504373f