### PR TITLE
Streamline HF dataset workflow and docs

### DIFF
--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -1,7 +1,9 @@
 # Datasets & Manifests
 [← Back to Documentation Index](README.md)
 
-See [Setup & Environment](ENV.md) for configuring caches.
+See [Setup & Environment](ENV.md) for configuring caches. All examples below
+assume the current working directory is the repository root (`transcribe`).
+Set `HF_TOKEN` in the environment if a dataset requires authentication.
 
 ## Reference formats
 - JSONL: one object per line with required fields:
@@ -35,45 +37,47 @@ Use the helper to pull datasets from Hugging Face and convert to our JSONL forma
 
 ```
 # Activate project-local caches (keeps HF audio under transcribe/.hf)
-. transcribe/env.ps1   # PowerShell (Windows)
-# or: source transcribe/env.sh  # bash (Linux/Runpod)
+# PowerShell (Windows)
+. env.ps1
+# or bash (Linux/Runpod)
+source env.sh
 
 # Common Voice v17 (ru)
-python transcribe/tools/build_manifest_hf.py --preset cv17-ru --out data/cv17_ru.jsonl --drop_empty
+python tools/build_manifest_hf.py --preset cv17-ru --out data/cv17_ru.jsonl --drop_empty
 
 # Multilingual LibriSpeech (ru)
-python transcribe/tools/build_manifest_hf.py --preset mls-ru --out data/mls_ru.jsonl --drop_empty
+python tools/build_manifest_hf.py --preset mls-ru --out data/mls_ru.jsonl --drop_empty
 
 # FLEURS (ru)
-python transcribe/tools/build_manifest_hf.py --preset fleurs-ru --out data/fleurs_ru.jsonl --drop_empty
+python tools/build_manifest_hf.py --preset fleurs-ru --out data/fleurs_ru.jsonl --drop_empty
 
 # Russian LibriSpeech (mirror may vary; script tries a few IDs)
-python transcribe/tools/build_manifest_hf.py --preset ruls --out data/ruls.jsonl --drop_empty
+python tools/build_manifest_hf.py --preset ruls --out data/ruls.jsonl --drop_empty
 
 # GOLOS (crowd/farfield; mirrors/configs may vary)
-python transcribe/tools/build_manifest_hf.py --preset golos-crowd --out data/golos_crowd.jsonl --drop_empty
-python transcribe/tools/build_manifest_hf.py --preset golos-farfield --out data/golos_farfield.jsonl --drop_empty
+python tools/build_manifest_hf.py --preset golos-crowd --out data/golos_crowd.jsonl --drop_empty
+python tools/build_manifest_hf.py --preset golos-farfield --out data/golos_farfield.jsonl --drop_empty
 
 # Podlodka Speech (Russian podcasts)
-python transcribe/tools/build_manifest_hf.py --preset podlodka --out data/podlodka.jsonl --drop_empty
+python tools/build_manifest_hf.py --preset podlodka --out data/podlodka.jsonl --drop_empty
 
 # Telephony (UniDataPro; may require auth)
-python transcribe/tools/build_manifest_hf.py \
+python tools/build_manifest_hf.py \
   --dataset UniDataPro/russian-speech-recognition-dataset \
   --split train+validation+test --audio_col audio --text_col transcript \
   --out data/telephony.jsonl --drop_empty
 
 # Optional non-speech (for anti-hallucination; emits empty text and nospeech=true)
-python transcribe/tools/build_manifest_hf.py --preset audioset-nonspeech --out data/nonspeech.jsonl
+python tools/build_manifest_hf.py --preset audioset-nonspeech --out data/nonspeech.jsonl
 
 # Mix manifests (concatenate)
-python transcribe/tools/mix_manifests.py \
+python tools/mix_manifests.py \
   --in cv=data/cv17_ru.jsonl --in mls=data/mls_ru.jsonl --in fleurs=data/fleurs_ru.jsonl \
   --in ruls=data/ruls.jsonl --in golos_c=data/golos_crowd.jsonl --in golos_f=data/golos_farfield.jsonl \
   --out data/ru_megamix_concat.jsonl --add_dataset_tag
 
 # Or sample to a target size with ratios
-python transcribe/tools/mix_manifests.py \
+python tools/mix_manifests.py \
   --in cv=data/cv17_ru.jsonl --in mls=data/mls_ru.jsonl --in fleurs=data/fleurs_ru.jsonl \
   --in ruls=data/ruls.jsonl --in golos_c=data/golos_crowd.jsonl --in golos_f=data/golos_farfield.jsonl \
   --out data/ru_megamix_500k.jsonl --target_size 500000 \
@@ -87,7 +91,7 @@ Here `golos_mix.jsonl` is Golos crowd+farfield concatenated.
 Run Canary on a manifest and keep only high‑quality rows (WER ≤ 0.15 by default):
 
 ```bash
-python transcribe/tools/filter_manifest_canary.py \
+python tools/filter_manifest_canary.py \
   --manifest data/cv17_ru.jsonl --out data/cv17_ru_sel.jsonl \
   --max_wer 0.15 --min_dur 1 --max_dur 35 --batch_size 64
 ```
@@ -98,7 +102,7 @@ Repeat for each dataset before mixing.
 After generating the individual manifests above, combine them using the methodology default ratios:
 
 ```bash
-python transcribe/tools/build_ru_stage1_mix.py \
+python tools/build_ru_stage1_mix.py \
   --golos data/golos_mix.jsonl --cv data/cv17_ru.jsonl \
   --ruls data/ruls.jsonl --podlodka data/podlodka.jsonl \
   --telephony data/telephony.jsonl --nonspeech data/nonspeech.jsonl \
@@ -113,7 +117,7 @@ Use `--ratios` to override.
 Fetch HF datasets, convert them to manifests, filter with Canary and build the Stage‑1 mix in one go:
 
 ```bash
-python transcribe/tools/build_ru_stage1_pipeline.py \
+python tools/build_ru_stage1_pipeline.py \
   --telephony data/telephony.jsonl --out_dir data \
   --target_size 1000000 --include_nonspeech --seed 42 --batch_size 64
 ```
@@ -136,7 +140,7 @@ Tips
 If a dataset has already been downloaded to a Hugging Face cache (`.hf/datasets/.../<hash>`), turn it into `train/validation/test` JSONL manifests with:
 
 ```bash
-python transcribe/tools/hf_cache_to_manifest.py \
+python tools/hf_cache_to_manifest.py \
   --dataset_dir .hf/datasets/bond005___rulibrispeech/default/0.0.0/<hash> \
   --out_dir data/rulibrispeech
 ```

--- a/docs/RUNPOD.md
+++ b/docs/RUNPOD.md
@@ -9,11 +9,13 @@ Recommended base image
 ```
 bash transcribe/training/runpod_setup.sh
 source transcribe/env.sh
+export HF_TOKEN=hf_xxx    # required for gated HF datasets/models
 ```
 - Option B (NeMo from Git main):
 ```
 bash transcribe/training/runpod_setup_nemo_main.sh
 source transcribe/env.sh
+export HF_TOKEN=hf_xxx
 ```
 Use Option B if you want latest NeMo features.
 

--- a/models/inference_canary.py
+++ b/models/inference_canary.py
@@ -153,6 +153,8 @@ def main() -> None:
     from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
     from transformers import pipeline as hf_pipeline
 
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
+
     # GPU lock
     repo_root = Path(__file__).resolve().parents[1]
     lock_path = repo_root / ".tmp" / "gpu.lock"
@@ -164,10 +166,17 @@ def main() -> None:
     use_pipeline_only = False
     try:
         processor = AutoProcessor.from_pretrained(
-            args.model_id, language=args.language, task=args.task, trust_remote_code=True
+            args.model_id,
+            language=args.language,
+            task=args.task,
+            trust_remote_code=True,
+            token=hf_token,
         )
         model = AutoModelForSpeechSeq2Seq.from_pretrained(
-            args.model_id, torch_dtype=torch.float16, trust_remote_code=True
+            args.model_id,
+            torch_dtype=torch.float16,
+            trust_remote_code=True,
+            token=hf_token,
         )
         model.to(device).eval()
     except Exception as e:
@@ -245,6 +254,7 @@ def main() -> None:
                 trust_remote_code=True,
                 generate_kwargs={"task": args.task, "language": args.language},
                 chunk_length_s=30,
+                token=hf_token,
             )
             for i in range(0, len(audio_files), bs):
                 batch_paths = audio_files[i : i + bs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ jiwer
 sentence-transformers
 torchaudio
 vosk
-datasets
-evaluate
+datasets<3
+evaluate<0.5
 accelerate
 lightning
 nemo_toolkit

--- a/tools/build_manifest_hf.py
+++ b/tools/build_manifest_hf.py
@@ -8,16 +8,16 @@ RuLS, GOLOS crowd/farfield, Podlodka, optional AudioSet non-speech).
 Examples:
 
   # Common Voice v17 RU (all splits), limit to 200k rows
-  python transcribe/tools/build_manifest_hf.py \
+  python tools/build_manifest_hf.py \
     --preset cv17-ru --out data/cv17_ru.jsonl --max_total 200000
 
   # Explicit dataset/config/split and columns
-  python transcribe/tools/build_manifest_hf.py \
+  python tools/build_manifest_hf.py \
     --dataset mozilla-foundation/common_voice_17_0 --config ru --split train+validation \
     --audio_col audio --text_col sentence --out data/cv17_ru_tval.jsonl
 
   # Add language/task fields
-  python transcribe/tools/build_manifest_hf.py --preset mls-ru --out data/mls_ru.jsonl \
+  python tools/build_manifest_hf.py --preset mls-ru --out data/mls_ru.jsonl \
     --source_lang ru --target_lang ru --task asr --pnc yes
 
 Notes:
@@ -32,15 +32,25 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from dataclasses import asdict
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-from datasets import Audio, load_dataset, concatenate_datasets
+
+# Allow running the script directly from the repository root without manually
+# tweaking PYTHONPATH. We add the parent directory of the repo so that
+# `import transcribe.*` works even when executed as `python tools/....`.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_PARENT = REPO_ROOT.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+from datasets import Audio, concatenate_datasets, load_dataset
 
 
 def configure_local_caches() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = REPO_ROOT
     hf = os.environ.get("HF_HOME") or str(repo_root / ".hf")
     os.environ.setdefault("HF_HOME", hf)
     os.environ.setdefault("TRANSFORMERS_CACHE", hf)

--- a/tools/build_ru_stage1_pipeline.py
+++ b/tools/build_ru_stage1_pipeline.py
@@ -16,6 +16,7 @@ Telephony data has no HF preset, so provide its manifest via `--telephony`.
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -23,9 +24,18 @@ from typing import List, Optional
 
 
 def run(cmd: List[str], cwd: Path) -> None:
-    """Run a subprocess in ``cwd``, echoing the command."""
+    """Run a subprocess in ``cwd``, echoing the command.
+
+    Adds the parent of ``cwd`` to ``PYTHONPATH`` so ``transcribe`` modules are
+    importable when using ``-m``.
+    """
     print("+", " ".join(cmd))
-    subprocess.run(cmd, check=True, cwd=cwd)
+    env = dict(os.environ)
+    parent = str(cwd.parent)
+    env["PYTHONPATH"] = (
+        parent + (":" + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    )
+    subprocess.run(cmd, check=True, cwd=cwd, env=env)
 
 
 def main() -> None:

--- a/tools/filter_manifest_canary.py
+++ b/tools/filter_manifest_canary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -14,9 +15,18 @@ from jiwer import wer
 
 
 def run(cmd: List[str], cwd: Path) -> None:
-    """Run a subprocess in ``cwd`` echoing the command."""
+    """Run a subprocess in ``cwd`` echoing the command.
+
+    Ensures the parent of ``cwd`` is on ``PYTHONPATH`` so the ``transcribe``
+    package is importable when invoking modules via ``-m``.
+    """
     print("+", " ".join(cmd))
-    subprocess.run(cmd, check=True, cwd=cwd)
+    env = dict(os.environ)
+    parent = str(cwd.parent)
+    env["PYTHONPATH"] = (
+        parent + (":" + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    )
+    subprocess.run(cmd, check=True, cwd=cwd, env=env)
 
 
 def transcribe_if_needed(

--- a/training/runpod_setup.sh
+++ b/training/runpod_setup.sh
@@ -38,3 +38,4 @@ except Exception as e:
   print('[WARN] NeMo import check failed:', e)
 PY
 echo "[READY] Setup complete."
+echo "[NOTE] In new shells, run 'source env.sh' to re-enable local caches."


### PR DESCRIPTION
## Summary
- allow running `build_manifest_hf.py` from repo root by injecting parent path and fixing cache locations
- pin datasets/evaluate versions to keep dataset scripts working
- update data preparation docs and Runpod setup note
- ensure filtering and Stage-1 pipeline utilities add parent dir to `PYTHONPATH` when invoking modules
- forward `HF_TOKEN` to Canary inference and mention token setup in Runpod guide

## Testing
- `python tools/build_manifest_hf.py --help`
- `python tools/filter_manifest_canary.py --help`
- `python models/inference_canary.py --help`
- `python tools/build_ru_stage1_pipeline.py --help`
- `bash -n training/runpod_setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0ac3dd8208326b9538a51a8672f02