### PR TITLE
Harden Canary manifest filtering

### DIFF
--- a/models/inference_canary_nemo.py
+++ b/models/inference_canary_nemo.py
@@ -26,7 +26,7 @@ def configure_local_caches() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     hf = os.environ.get("HF_HOME") or str(repo_root / ".hf")
     os.environ.setdefault("HF_HOME", hf)
-    os.environ.setdefault("TRANSFORMERS_CACHE", hf)
+    # os.environ.setdefault("TRANSFORMERS_CACHE", hf)  # HF_HOME/HF_HUB_CACHE are sufficient
     os.environ.setdefault("HF_HUB_CACHE", str(Path(hf) / "hub"))
     os.environ.setdefault("TORCH_HOME", str(repo_root / ".torch"))
     tmp = str(repo_root / ".tmp")


### PR DESCRIPTION
## Summary
- make Canary manifest filtering script more resilient by using cross-platform PYTHONPATH setup and fallback invocation mode, and ensure predictions file is produced
- silence TRANSFORMERS_CACHE warning in Canary inference helper

## Testing
- `python -m py_compile tools/filter_manifest_canary.py models/inference_canary_nemo.py`
- `python tools/filter_manifest_canary.py --help`
- `python models/inference_canary_nemo.py --help` *(fails: ModuleNotFoundError: No module named 'torch'; attempted to install but download unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1994a544883269e7d54953556094f