### PR TITLE
feat: update HF manifest builder

### DIFF
--- a/tools/build_manifest_hf.py
+++ b/tools/build_manifest_hf.py
@@ -3,34 +3,44 @@
 """
 Build JSONL manifests from Hugging Face datasets.
 
-Each output line: {"audio_filepath": "<path>", "text": "<transcript>"}
+Каждая строка вывода: {"audio_filepath": "<path>", "text": "<transcript>"}
 
-Usage examples:
+Примеры:
   # Common Voice 17 (RU) — все сплиты
   python tools/build_manifest_hf.py --preset cv17-ru --out data/cv17_ru.jsonl --drop_empty
 
-  # RuLibriSpeech (путь 'bond005/rulibrispeech' или 'bond005___rulibrispeech')
-  python tools/build_manifest_hf.py --preset rulibrispeech --out data/rulibri.jsonl --drop_empty
+  # RuLibriSpeech (алиас: ruls, mls-ru)
+  python tools/build_manifest_hf.py --preset ruls --out data/ruls.jsonl --drop_empty
 
-  # Произвольный датасет/конфиг/сплит
+  # FLEURS (ru_ru)
+  python tools/build_manifest_hf.py --preset fleurs-ru --out data/fleurs_ru.jsonl --drop_empty
+
+  # GOLOS (crowd/farfield)
+  python tools/build_manifest_hf.py --preset golos-crowd --out data/golos_crowd.jsonl --drop_empty
+  python tools/build_manifest_hf.py --preset golos-farfield --out data/golos_farfield.jsonl --drop_empty
+
+  # Podlodka
+  python tools/build_manifest_hf.py --preset podlodka --out data/podlodka.jsonl --drop_empty
+
+  # Произвольный датасет/конфиг/сплит с кастомными колонками
   python tools/build_manifest_hf.py \
-      --name mozilla-foundation/common_voice_17_0 --config ru \
-      --split train+validation+test --out data/cv17_ru.jsonl
+      --dataset UniDataPro/russian-speech-recognition-dataset \
+      --split train+validation+test --audio_col audio --text_col transcript \
+      --out data/telephony.jsonl --drop_empty
 
 Notes:
-  - По умолчанию включен trust_remote_code=True (можно отключить флагом --no-trust-remote-code).
-  - Для фильтров по длительности можно передать --min-sec / --max-sec (требует soundfile).
+  - По умолчанию trust_remote_code=True (можно отключить --no-trust-remote-code).
+  - Для фильтров по длительности можно передать --min-sec / --max-sec (нужен soundfile).
 """
 
 from __future__ import annotations
 import argparse
 import json
-import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
-# Lazy imports (datasets может не стоять у некоторых окружений)
-from datasets import load_dataset
+from datasets import load_dataset  # убедитесь, что в requirements есть: datasets>=2.19.0
+# soundfile нужен только если используете фильтры по длительности
 
 
 # ----------------------------- Presets --------------------------------- #
@@ -53,45 +63,94 @@ PRESETS: Dict[str, Dict[str, Any]] = {
         "split": "train+validation+test",
         "mapper": "common_voice17",
     },
-    # RuLibriSpeech (комьюнити-репозиторий)
-    "rulibrispeech": {
-        "name": "bond005/rulibrispeech",  # допускаем и bond005___rulibrispeech (см. normalize_repo_id)
+
+    # Russian LibriSpeech (RuLS). В MLS нет русского — используем RuLS на HF.
+    "ruls": {
+        "name": "istupakov/russian_librispeech",
         "config": None,
-        "split": "train+validation+test",  # если в репо нет всех трёх — укажи нужные вручную через --split
+        "split": "train+validation+test",
         "mapper": "generic_text_audio",
     },
-    # Добавляй свои:
-    # "my-preset": {"name": "...", "config": "...", "split": "...", "mapper": "generic_text_audio"},
+    "rulibrispeech": {  # синоним
+        "name": "istupakov/russian_librispeech",
+        "config": None,
+        "split": "train+validation+test",
+        "mapper": "generic_text_audio",
+    },
+    "mls-ru": {  # алиас на RuLS, т.к. в facebook/multilingual_librispeech нет 'ru'
+        "name": "istupakov/russian_librispeech",
+        "config": None,
+        "split": "train+validation+test",
+        "mapper": "generic_text_audio",
+    },
+
+    # FLEURS RU
+    "fleurs-ru": {
+        "name": "google/fleurs",
+        "config": "ru_ru",
+        "split": "train+validation+test",
+        "mapper": "generic_text_audio",  # у FLEURS поля path/audio/transcription
+    },
+
+    # GOLOS (адаптированные сабсеты на HF)
+    "golos-crowd": {
+        "name": "bond005/sberdevices_golos_10h_crowd",
+        "config": None,
+        "split": "train+test",
+        "mapper": "generic_text_audio",
+    },
+    "golos-farfield": {
+        "name": "bond005/sberdevices_golos_100h_farfield",
+        "config": None,
+        "split": "train+test",
+        "mapper": "generic_text_audio",
+    },
+
+    # Podlodka
+    "podlodka": {
+        "name": "bond005/podlodka_speech",
+        "config": None,
+        "split": "train+validation+test",
+        "mapper": "generic_text_audio",
+    },
 }
 
 
 # --------------------------- Mappers ----------------------------------- #
 
+def _extract_audio_path(value: Any) -> Optional[str]:
+    """
+    Приводим разные варианты к строке пути:
+      - dict (Audio feature): берем value["path"]
+      - str: возвращаем как есть
+    """
+    if isinstance(value, dict):
+        p = value.get("path")
+        return p if isinstance(p, str) and p else None
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
 def _get_audio_path(ex: Dict[str, Any]) -> Optional[str]:
     """
     Универсальный способ вытащить путь к аудио.
-    Приоритет: ex["audio"]["path"] -> ex["path"] -> ex["audio_filepath"]
+    Приоритет: ex["audio"]["path"] -> ex["path"] -> ex["file"] -> ex["audio_filepath"]
     """
-    audio = ex.get("audio")
-    if isinstance(audio, dict):
-        p = audio.get("path")
-        if p:
-            return p
-    p = ex.get("path")
-    if isinstance(p, str) and p:
-        return p
-    p = ex.get("audio_filepath")
-    if isinstance(p, str) and p:
-        return p
+    for key in ("audio", "path", "file", "audio_filepath"):
+        if key in ex:
+            p = _extract_audio_path(ex[key])
+            if p:
+                return p
     return None
 
 
 def _get_text(ex: Dict[str, Any]) -> str:
     """
     Универсальный способ вытащить текст.
-    Частые поля: "sentence" (CV), "text", "normalized_text", "transcript".
+    Частые поля: "sentence" (CV), "text", "normalized_text", "transcript(ion)".
     """
-    for k in ("sentence", "text", "normalized_text", "normalized", "transcript", "transcription"):
+    for k in ("sentence", "text", "normalized_text", "normalized", "transcript", "transcription", "raw_transcription"):
         v = ex.get(k)
         if isinstance(v, str) and v.strip():
             return v.strip()
@@ -116,13 +175,36 @@ def map_common_voice17(ex: Dict[str, Any]) -> Optional[Dict[str, str]]:
 def map_generic_text_audio(ex: Dict[str, Any]) -> Optional[Dict[str, str]]:
     """
     Маппер "по умолчанию": ищет аудио и текст в типичных местах.
-    Подходит для многих комьюнити-датасетов, включая RuLibriSpeech.
+    Подходит для многих датасетов (RuLS, FLEURS, GOLOS-сабсеты, Podlodka и т.п.).
     """
     path = _get_audio_path(ex)
     text = _get_text(ex)
     if not path:
         return None
     return {"audio_filepath": path, "text": text or ""}
+
+
+def make_custom_mapper(audio_col: str, text_col: str):
+    """
+    Маппер с явными названиями колонок (для --audio_col/--text_col).
+    """
+    a_col = audio_col.strip()
+    t_col = text_col.strip()
+
+    def _mapper(ex: Dict[str, Any]) -> Optional[Dict[str, str]]:
+        if a_col not in ex or t_col not in ex:
+            return None
+        path = _extract_audio_path(ex[a_col])
+        if not path:
+            return None
+        text_val = ex[t_col]
+        if isinstance(text_val, str):
+            txt = text_val.strip()
+        else:
+            txt = str(text_val) if text_val is not None else ""
+        return {"audio_filepath": path, "text": txt}
+
+    return _mapper
 
 
 MAPPER_FUNCS = {
@@ -135,15 +217,14 @@ MAPPER_FUNCS = {
 
 def compute_duration_seconds(path: str) -> Optional[float]:
     """
-    По желанию: оценка длительности через soundfile (без декодирования в numpy).
-    Возвращает None, если не удалось.
+    Оценка длительности через soundfile без полного декодирования.
+    Возвращает None, если не удалось (или soundfile не установлен).
     """
     try:
-        import soundfile as sf
+        import soundfile as sf  # type: ignore
         info = sf.info(path)
-        if info.frames and info.samplerate:
+        if getattr(info, "frames", 0) and getattr(info, "samplerate", 0):
             return float(info.frames) / float(info.samplerate)
-        # иногда soundfile не даёт frames — попытаемся прочесть заголовок
         return getattr(info, "duration", None)
     except Exception:
         return None
@@ -153,13 +234,21 @@ def compute_duration_seconds(path: str) -> Optional[float]:
 
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-    # Способ 1: пресет
-    ap.add_argument("--preset", type=str, default=None, help=f"One of: {', '.join(PRESETS.keys())}")
 
-    # Способ 2: ручное задание
-    ap.add_argument("--name", type=str, default=None, help="HF dataset repo id, e.g. mozilla-foundation/common_voice_17_0")
+    # Вариант 1: пресет
+    ap.add_argument("--preset", type=str, default=None, help=f"One of: {', '.join(sorted(PRESETS.keys()))}")
+
+    # Вариант 2: ручной
+    ap.add_argument("--dataset", dest="name", type=str, default=None,
+                    help="HF dataset repo id (alias: --name), e.g. mozilla-foundation/common_voice_17_0")
+    ap.add_argument("--name", type=str, default=None, help=argparse.SUPPRESS)
     ap.add_argument("--config", type=str, default=None, help="HF dataset config (language, etc.)")
-    ap.add_argument("--split", type=str, default="train", help="split spec, e.g. 'train' or 'train+validation+test'")
+    ap.add_argument("--split", type=str, default="train",
+                    help="split spec, e.g. 'train' or 'train+validation+test'")
+
+    # Кастомные колонки
+    ap.add_argument("--audio_col", type=str, default=None, help="Audio column name (e.g., 'audio')")
+    ap.add_argument("--text_col", type=str, default=None, help="Text column name (e.g., 'transcript')")
 
     ap.add_argument("--out", type=str, required=True, help="Output JSONL path")
 
@@ -168,14 +257,15 @@ def build_parser() -> argparse.ArgumentParser:
     ap.add_argument("--max-sec", type=float, default=None, help="Keep only samples with duration <= max-sec")
     ap.add_argument("--max-rows", type=int, default=None, help="Limit number of rows written")
 
-    # trust_remote_code по умолчанию ВКЛ — чтобы CV17 и комьюнити-датасеты грузились без ошибки
+    # trust_remote_code по умолчанию ВКЛ — чтобы CV17/FLEURS и комьюнити-репозитории грузились без ошибки
     ap.add_argument("--trust-remote-code", dest="trust_remote_code", action="store_true", default=True,
                     help="Allow running dataset repo code (default: True)")
     ap.add_argument("--no-trust-remote-code", dest="trust_remote_code", action="store_false",
                     help="Disable running dataset repo code")
 
+    # Явный выбор маппера (опционально)
     ap.add_argument("--mapper", type=str, default=None,
-                    help=f"Force mapper: {', '.join(MAPPER_FUNCS.keys())}. If omitted, chosen by preset or heuristics.")
+                    help=f"Force mapper: {', '.join(MAPPER_FUNCS.keys())}.")
 
     return ap
 
@@ -193,9 +283,22 @@ def choose_mapper(name: str, forced: Optional[str]) -> str:
     return "generic_text_audio"
 
 
+def iter_examples(ds):
+    """Универсальный итератор по датасету (Dataset или IterableDataset)."""
+    try:
+        # Обычный Dataset
+        for ex in ds:
+            yield ex
+    except TypeError:
+        # На всякий (streaming) — тоже итерируемо
+        for ex in ds:
+            yield ex
+
+
 def main():
     args = build_parser().parse_args()
 
+    # Извлекаем параметры из пресета или ручного режима
     if args.preset:
         if args.preset not in PRESETS:
             raise SystemExit(f"Unknown preset '{args.preset}'. Available: {list(PRESETS.keys())}")
@@ -206,32 +309,39 @@ def main():
         mapper_key = p.get("mapper")
     else:
         if not args.name:
-            raise SystemExit("Either --preset or --name must be provided.")
+            raise SystemExit("Either --preset or --dataset must be provided.")
         name = normalize_repo_id(args.name)
         config = args.config
         split = args.split
-        mapper_key = None  # выберем ниже эвристикой
+        mapper_key = None  # выберем ниже эвристикой или по колонкам
 
-    if args.mapper:
-        mapper_key = args.mapper
-    if not mapper_key:
-        mapper_key = choose_mapper(name, forced=None)
-
-    mapper = MAPPER_FUNCS[mapper_key]
+    # Кастомные колонки → свой маппер
+    mapper = None
+    if args.audio_col and args.text_col:
+        mapper = make_custom_mapper(args.audio_col, args.text_col)
+    else:
+        if args.mapper:
+            mapper_key = args.mapper
+        if not mapper_key:
+            mapper_key = choose_mapper(name, forced=None)
+        mapper = MAPPER_FUNCS[mapper_key]
 
     # Подготовим выходную папку
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     print(f"[INFO] Loading dataset: name='{name}', config='{config}', split='{split}', trust_remote_code={args.trust_remote_code}")
-    ds = load_dataset(
-        path=name,
-        name=config,
-        split=split,
-        trust_remote_code=args.trust_remote_code,
-    )
+    try:
+        ds = load_dataset(
+            path=name,
+            name=config,
+            split=split,
+            trust_remote_code=args.trust_remote_code,
+        )
+    except Exception as e:
+        raise SystemExit(f"[ERROR] Failed to load dataset '{name}' (config={config}, split={split}).\n{e}")
 
-    total = len(ds)
+    total = len(ds) if hasattr(ds, "__len__") else None
     written = 0
     skipped_empty = 0
     skipped_dur = 0
@@ -240,7 +350,7 @@ def main():
     want_max = args.max_sec is not None
 
     with out_path.open("w", encoding="utf-8") as f:
-        for i, ex in enumerate(ds):
+        for i, ex in enumerate(iter_examples(ds)):
             row = mapper(ex)
             if row is None:
                 skipped_empty += 1
@@ -254,10 +364,7 @@ def main():
             # duration filters (optional)
             if (want_min or want_max) and row.get("audio_filepath"):
                 dur = compute_duration_seconds(row["audio_filepath"])
-                if dur is None:
-                    # не удалось оценить — считаем, что подходит (или можно скипнуть, если нужно строго)
-                    pass
-                else:
+                if dur is not None:
                     if want_min and dur < float(args.min_sec):
                         skipped_dur += 1
                         continue
@@ -272,12 +379,15 @@ def main():
                 print(f"[INFO] Reached --max-rows={args.max_rows}, stopping early.")
                 break
 
-            if (i + 1) % 500 == 0:
+            if total is not None and (i + 1) % 500 == 0:
                 print(f"[PROGRESS] {i + 1}/{total} processed, {written} written...")
+            elif total is None and (i + 1) % 1000 == 0:
+                print(f"[PROGRESS] {i + 1} processed, {written} written...")
 
-    print(f"[DONE] Processed: {total}, written: {written}, skipped_empty: {skipped_empty}, skipped_dur: {skipped_dur}")
+    print(f"[DONE] Written: {written}, skipped_empty: {skipped_empty}, skipped_dur: {skipped_dur}")
     print(f"[OUT] {out_path}")
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- extend build_manifest_hf script with presets for common datasets (cv17-ru, ruls, fleurs-ru, golos, podlodka)
- allow custom audio/text columns and dataset repo IDs
- add duration filtering and universal iteration helpers

## Testing
- `python tools/build_manifest_hf.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c1a78e110483268ee7f7d2eaeb5838